### PR TITLE
Simple typo fix when jail couldn't be created.

### DIFF
--- a/share/appjail/cmd/cmd
+++ b/share/appjail/cmd/cmd
@@ -193,7 +193,7 @@ cmd_jexec()
 	fi
 
 	if ! lib_jail_created_by_appjail "${jail_name}"; then
-		lib_warn -- "${jail_name} was not been created by appjail."
+		lib_warn -- "${jail_name} has not been created by appjail."
 		return 0
 	fi
 

--- a/share/appjail/cmd/cpuset
+++ b/share/appjail/cmd/cpuset
@@ -55,7 +55,7 @@ cpuset_main()
 	fi
 
 	if ! lib_jail_created_by_appjail "${jail_name}"; then
-		lib_warn -- "${jail_name} was not been created by appjail."
+		lib_warn -- "${jail_name} has not been created by appjail."
 		exit 0
 	fi
 

--- a/share/appjail/cmd/limits
+++ b/share/appjail/cmd/limits
@@ -708,7 +708,7 @@ limits_stats()
 	fi
 
 	if ! lib_jail_created_by_appjail "${jail_name}"; then
-		lib_warn -- "${jail_name} was not been created by appjail."
+		lib_warn -- "${jail_name} has not been created by appjail."
 		return 0
 	fi
 

--- a/share/appjail/cmd/login
+++ b/share/appjail/cmd/login
@@ -81,7 +81,7 @@ login_main()
 	fi
 
 	if ! lib_jail_created_by_appjail "${jail_name}"; then
-		lib_warn -- "${jail_name} was not been created by appjail."
+		lib_warn -- "${jail_name} has not been created by appjail."
 		return 0
 	fi
 

--- a/share/appjail/cmd/makejail
+++ b/share/appjail/cmd/makejail
@@ -512,7 +512,7 @@ makejail_run()
 
 		if lib_jail_exists "${MAKEJAIL_JAILNAME}"; then
 			if ! lib_jail_created_by_appjail "${MAKEJAIL_JAILNAME}"; then
-				lib_warn -- "${MAKEJAIL_JAILNAME} was not been created by appjail."
+				lib_warn -- "${MAKEJAIL_JAILNAME} has not been created by appjail."
 				exit 0
 			fi
 		fi

--- a/share/appjail/cmd/network
+++ b/share/appjail/cmd/network
@@ -274,7 +274,7 @@ network_assign()
 	fi
 
 	if ! lib_jail_created_by_appjail "${jail_name}"; then
-		lib_warn -- "${jail_name} was not been created by appjail."
+		lib_warn -- "${jail_name} has not been created by appjail."
 		return 0
 	fi
 

--- a/share/appjail/cmd/pkg
+++ b/share/appjail/cmd/pkg
@@ -129,7 +129,7 @@ pkg_chroot()
 			fi
 
 			if ! lib_jail_created_by_appjail "${jail_name}"; then
-				lib_warn -- "${jail_name} was not been created by appjail."
+				lib_warn -- "${jail_name} has not been created by appjail."
 				exit 0
 			fi
 			;;
@@ -175,7 +175,7 @@ pkg_jail()
 	fi
 
 	if ! lib_jail_created_by_appjail "${jail_name}"; then
-		lib_warn -- "${jail_name} was not been created by appjail."
+		lib_warn -- "${jail_name} has not been created by appjail."
 		exit 0
 	fi
 

--- a/share/appjail/cmd/run
+++ b/share/appjail/cmd/run
@@ -108,7 +108,7 @@ run_main()
 	fi
 
 	if ! lib_jail_created_by_appjail "${jail_name}"; then
-		lib_warn -- "${jail_name} was not been created by appjail."
+		lib_warn -- "${jail_name} has not been created by appjail."
 		return 0
 	fi
 

--- a/share/appjail/cmd/start
+++ b/share/appjail/cmd/start
@@ -134,7 +134,7 @@ start_main()
 
 	if lib_jail_exists "${jail_name}"; then
 		if ! lib_jail_created_by_appjail "${jail_name}"; then
-			lib_warn -- "${jail_name} was not been created by appjail."
+			lib_warn -- "${jail_name} has not been created by appjail."
 			exit 0
 		fi
 

--- a/share/appjail/cmd/stop
+++ b/share/appjail/cmd/stop
@@ -133,7 +133,7 @@ stop_main()
 	fi
 
 	if ! lib_jail_created_by_appjail "${jail_name}"; then
-		lib_warn -- "${jail_name} was not been created by appjail."
+		lib_warn -- "${jail_name} has not been created by appjail."
 		return 0
 	fi
 


### PR DESCRIPTION
We could have this say either "has not been created" as I set it, or "was not created"