### PR TITLE
Use more likely internal DNS IP address

### DIFF
--- a/share/man/man7/appjail-tutorial.7
+++ b/share/man/man7/appjail-tutorial.7
@@ -382,7 +382,7 @@ preferable to change things as little as possible.
 .Bd -literal -offset indent
 # sysrc cloned_interfaces+="tap0"
 # sysrc ifconfig_tap0_name="ajdns"
-# sysrc ifconfig_ajdns="inet 172.0.0.1/32"
+# sysrc ifconfig_ajdns="inet 172.16.0.1/32"
 # service netif cloneup
 # service netif start ajdns
 .Ed
@@ -414,7 +414,7 @@ file at
 .Pa %%PREFIX%%/etc/appjail/
 should be very simple.
 .Bd -literal -offset indent
-nameserver 172.0.0.1
+nameserver 172.16.0.1
 .Ed
 .Pp
 Now our jails can use a DNS hostname to communicate with another jail. That is fine,


### PR DESCRIPTION
I _think_ the intent of this section is to use a Class B private IP for the tap interface, not a public IP.

I also noticed something similar in the appjail-quick manpage but that was merely in the range of "interesting" example output so not sure if that's as important.